### PR TITLE
chore(ci): configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    cooldown:
+      default-days: 6
+    schedule:
+      interval: "cron"
+      cronjob: "0 11 * * 2,4"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    cooldown:
+      default-days: 6
+    schedule:
+      interval: "cron"
+      cronjob: "0 11 * * 2,4"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    cooldown:
+      default-days: 6
+    schedule:
+      interval: "cron"
+      cronjob: "0 11 * * 2,4"


### PR DESCRIPTION
Dependabot Configuration

- Run every **`Tuesday & Thursday at 11:00am UCT`**
- Set cooldown time to **`6`**
- Check: **`docker`**, **`github-actions`**, **`npm`**