### PR TITLE
chore(ci): update workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24.x
 
@@ -80,25 +83,30 @@ jobs:
 
       - name: Assert that invalid tests failed
         run: |
-          if [ "${{ steps.test2.outcome }}" != "failure" ]; then
+          if [ "${STEPS_TEST2_OUTCOME}" != "failure" ]; then
             echo "Test 2 did not fail as expected"
             exit 1
           fi
 
-          if [ "${{ steps.test3.outcome }}" != "failure" ]; then
+          if [ "${STEPS_TEST3_OUTCOME}" != "failure" ]; then
             echo "Test 3 did not fail as expected"
             exit 1
           fi
 
-          if [ "${{ steps.test4.outcome }}" != "failure" ]; then
+          if [ "${STEPS_TEST4_OUTCOME}" != "failure" ]; then
             echo "Test 4 did not fail as expected"
             exit 1
           fi
 
-          if [ "${{ steps.test5.outcome }}" != "failure" ]; then
+          if [ "${STEPS_TEST5_OUTCOME}" != "failure" ]; then
             echo "Test 5 did not fail as expected"
             exit 1
           fi
+        env:
+          STEPS_TEST2_OUTCOME: ${{ steps.test2.outcome }}
+          STEPS_TEST3_OUTCOME: ${{ steps.test3.outcome }}
+          STEPS_TEST4_OUTCOME: ${{ steps.test4.outcome }}
+          STEPS_TEST5_OUTCOME: ${{ steps.test5.outcome }}
 
   codeql:
     name: CodeQL
@@ -110,8 +118,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: github/codeql-action/init@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
           languages: javascript, actions
           queries: security-and-quality
@@ -119,4 +130,4 @@ jobs:
             paths-ignore:
               - node_modules
 
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1


### PR DESCRIPTION
Update CI workflow to apply zizmor suggestions

- Set **`persist-credentials`** to **`false`** for **`actions/checkout`**
- Switch to **hash-pinned** actions.
- Use of **env** variables instead of calling onto **steps**