### PR TITLE
feat: prepare 3.0.0 & update documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Contributing
+
+Anyone can contribute to this project. Feel free to fork and create a branch from `main` and submit a pull request on GitHub.
+
+There are multiple ways to contribute to this project, for example:
+
+- Report bugs
+- Improve docs
+- Contribute code
+
+Before submitting a bug report, check whether an issue has already been opened in the GitHub issue tracker.
+
+We look forward to your contributions!

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,87 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Development
+
+## Setup
+
+1. Install Node.js and npm.
+   
+   It is recommended to install at least the versions specified in the `engines` field of `package.json`.
+   
+   To more closely match with what is executed in GitHub Actions, use the versions specified in the `Dockerfile`.
+
+2. Install Docker
+
+    Docker must be installed and running if you are making changes to the `Dockerfile` or want to test using the same Docker image that is used in GitHub Actions.
+
+3. Install npm dependencies.
+
+    ```bash
+    npm ci
+    ```
+
+## Unit Testing
+
+There are currently no unit tests at the moment and is one of the TODO items.
+
+## Linting
+
+During development, you should run the linter to ensure that the code follows our coding standards:
+
+```bash
+npm run lint
+```
+
+### Fixing Lint Issues
+
+In many cases, lint warnings can be fixed automatically with:
+
+```bash
+npm run lint:fix
+```
+
+If an issue cannot be resolved automatically, it will require manual review and correction.
+
+
+## Testing Docker Build Locally
+
+This action can be tested locally by building the Docker image and running it against a target directory.
+
+1. Ensure Docker is installed and running.
+2. Clone this repository and change your working directory to the cloned repository.
+3. Build the Docker image:
+
+  ```bash
+  docker build -t license-checker-action .
+  ```
+
+4. Navigate to the target directory you want to analyze.
+5. Run the image:
+
+  ```bash
+  docker run --rm -t \
+    --cap-drop=ALL \
+    --security-opt=no-new-privileges \
+    -e GITHUB_WORKSPACE=/workspace \
+    -e INPUT_LICENSE_CONFIG=false \
+    -e INPUT_INCLUDE_ASF_CATEGORY_A=false \
+    -v "$(pwd):/workspace:ro" \
+    license-checker-action
+  ```

--- a/README.md
+++ b/README.md
@@ -97,26 +97,3 @@ ignored-packages:
   However, you can combine `include-asf-category-a` with `license-config` to allow additional licenses or ignore specific packages.
 
   **Note**: It is not currently possible to **exclude specific licenses** from the predefined `include-asf-category-a` list. If you need more granular control, you should **avoid using `include-asf-category-a`** and instead define your own full allow list using `license-config`.
-
-## License
-
-  ```text
-  Licensed to the Apache Software Foundation (ASF) under one or more
-  contributor license agreements.  See the NOTICE file distributed with
-  this work for additional information regarding copyright ownership.
-  The ASF licenses this file to You under the Apache License, Version 2.0
-  (the "License"); you may not use this file except in compliance with
-  the License.  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-  ```
-
-## Contribution
-
-If you want to contribute, feel free to branch from main and provide a pull request via Github.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,10 @@
       },
       "devDependencies": {
         "@cordova/eslint-config": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=24",
+        "npm": ">=11"
       }
     },
     "node_modules/@cordova/eslint-config": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "license-checker-action",
-  "version": "2.1.1-dev.0",
+  "version": "3.0.0-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "license-checker-action",
-      "version": "2.1.1-dev.0",
+      "version": "3.0.0-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
         "license-checker-rseidelsohn": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -16,5 +16,9 @@
   },
   "devDependencies": {
     "@cordova/eslint-config": "^6.0.1"
+  },
+  "engines": {
+    "node": ">=24",
+    "npm": ">=11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "lint:fix": "npm run lint -- --fix"
   },
   "author": "Bryan \"Erisu\" Ellis",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "license-checker-action",
-  "version": "2.1.1-dev.0",
+  "version": "3.0.0-dev.0",
   "description": "Audits NPM Package Licenses",
   "main": "license-checker.js",
   "type": "module",


### PR DESCRIPTION
- Pinned 3.0.0-dev.0
- Updated README
- Added DEVELOPMENT & CONTRIBUTING
- Added engine requirements for node and npm to match with `license-checker-rseidelsohn`
- Removed License from README as there is a LICENSE file and license headers
- Added `npm run lint:fix`