### PR TITLE
feat: add --include-dev flag to include devDependencies

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -82,6 +82,7 @@ This action can be tested locally by building the Docker image and running it ag
     -e GITHUB_WORKSPACE=/workspace \
     -e INPUT_LICENSE_CONFIG=false \
     -e INPUT_INCLUDE_ASF_CATEGORY_A=false \
+    -e INPUT_INCLUDE_DEV=false \
     -v "$(pwd):/workspace:ro" \
     license-checker-action
   ```

--- a/README.md
+++ b/README.md
@@ -97,3 +97,16 @@ ignored-packages:
   However, you can combine `include-asf-category-a` with `license-config` to allow additional licenses or ignore specific packages.
 
   **Note**: It is not currently possible to **exclude specific licenses** from the predefined `include-asf-category-a` list. If you need more granular control, you should **avoid using `include-asf-category-a`** and instead define your own full allow list using `license-config`.
+
+* **`include-dev`**
+
+  By default, only production dependency licenses are checked. Set `include-dev` to `true` to include development dependencies as well.
+
+  ### Example workflow
+
+  ```yaml
+  # Check Node.js package licenses
+  - uses: erisu/license-checker-action@v2
+    with:
+      include-dev: true
+  ```

--- a/action.yml
+++ b/action.yml
@@ -29,9 +29,15 @@ inputs:
     required: false
     default: 'false'
 
+  include-dev:
+    description: Should include development dependencies when checking
+    required: false
+    default: 'false'
+
 runs:
   using: docker
   image: Dockerfile
   env:
     INPUT_LICENSE_CONFIG: ${{ inputs.license-config }}
     INPUT_INCLUDE_ASF_CATEGORY_A: ${{ inputs.include-asf-category-a }}
+    INPUT_INCLUDE_DEV: ${{ inputs.include-dev }}

--- a/license-checker.js
+++ b/license-checker.js
@@ -37,6 +37,10 @@ const cmdOptions = {
   },
   'include-asf-category-a': {
     type: 'boolean'
+  },
+  'include-dev': {
+    type: 'boolean',
+    default: false
   }
 };
 
@@ -59,9 +63,12 @@ const rawIncludeASFCategoryA =
     : process.env.INPUT_INCLUDE_ASF_CATEGORY_A;
 const includeASFCategoryA = rawIncludeASFCategoryA === true || rawIncludeASFCategoryA === 'true';
 
+const includeDev = !!(values['include-dev'] || process.env.INPUT_INCLUDE_DEV);
+
 console.log('INPUTS:', {
   licenseConfigPath,
-  includeASFCategoryA
+  includeASFCategoryA,
+  includeDev
 });
 
 // Getting license config file.
@@ -79,7 +86,7 @@ if (licenseConfigPath && licenseConfigPath !== 'false') {
 const options = {
   start: workspace,
   excludePrivatePackages: true,
-  production: true
+  production: !includeDev
 };
 
 if (!configFile) {


### PR DESCRIPTION
Add `--include-dev` flag to include `devDependencies` when checking licenses